### PR TITLE
Move base styles out of custom.css

### DIFF
--- a/layout/_partial/footer.ejs
+++ b/layout/_partial/footer.ejs
@@ -1,5 +1,5 @@
 <footer class="blog-footer">
-  <div class="outer">
+  <div class="container">
     <div id="footer-info" class="inner">
       &copy; <%= date(new Date(), 'YYYY') %> <%= config.author || config.title %><br>
       Powered by <a href="http://hexo.io/" target="_blank">Hexo</a>

--- a/source/css/custom.css
+++ b/source/css/custom.css
@@ -1,7 +1,14 @@
-/** Custom Bootstrap Overrides (and other styles) */
-/*
- * Globals
+/**
+ * Custom Bootstrap and Theme Overrides
+ *
+ * Bootstrap designers: Feel free to remove all of the styles in this
+ * file to start a fresh new design. Most of the critical/functional
+ * styles are found within the other CSS files, with this one included last.
+ *
+ * Bootstrap and Hexo markdown style overrides would typically happen here.
  */
+
+/* Globals */
 
 body {
   font-family: Georgia, "Times New Roman", Times, serif;
@@ -42,13 +49,6 @@ code {
 }
 .nav-pills>li>a {
   border-radius: 30px;
-}
-
-.left, .alignleft {
-  float: left;
-}
-.right, .alignright {
-  float: right;
 }
 
 /* Override Bootstrap's default container width */
@@ -180,13 +180,6 @@ code {
   padding-left: 0;
   list-style: none;
 }
-.sidebar-module-list-count {
-  padding-left: 5px;
-  color: #999;
-  font-size: 0.85em;
-}
-.sidebar-module-list-count:before { content: "("; }
-.sidebar-module-list-count:after { content: ")"; }
 .sidebar-module-list-child {
   padding-left: 25px;
 }
@@ -224,41 +217,7 @@ code {
 .article-meta a {
   color: inherit;
 }
-.article-date:before,
-.article-author:before,
-.article-category-link:before {
-  display: inline-block;
-  font-family: FontAwesome;
-  margin-right: 0.25em;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-}
-.article-date:before { content: "\f073"; }
-.article-author:before { content: "\f007"; }
-.article-category-link:before { content: "\f07b"; }
 
-.article-entry {
-  overflow: hidden;
-}
-
-/* blockquote */
-.article-entry blockquote footer cite {
-  display: inline-block;
-}
-.article-entry blockquote footer cite::before {
-  content: "~";
-  padding: 0px 0.5em;
-}
-
-.article-entry .pullquote.right {
-  margin-right: 0.5em;
-  margin-left: 1em;
-}
-.article-entry .pullquote {
-  text-align: left;
-  width: 45%;
-  margin: 0;
-}
 
 /* article footer content */
 .article-footer {
@@ -282,90 +241,6 @@ code {
   text-decoration: underline;
 }
 
-.article-comment-link { display: inline-block; }
-.article-share-link {
-  cursor: pointer;
-  float: right;
-  margin-left: 20px;
-}
-
-.article-tag-list {
-  margin: 0;
-  padding: 0;
-  list-style-type: none;
-}
-.article-tag-list-item {
-  display: inline-block;
-  margin-right: 15px;
-}
-.article-tag-list-link:before {
-  display: inline-block;
-  font-family: FontAwesome;
-  content: "\f02b";
-  margin-right: 0.25em;
-  text-rendering: auto;
-  -webkit-font-smoothing: antialiased;
-}
-
-/* prev/next navigation between articles */
-#article-nav {
-  margin-top: 30px;
-}
-#article-nav>li {
-  padding: 2px;
-  font-size: 0.8em;
-}
-#article-nav>li>a {
-  border: 1px solid #337ab7;
-}
-#article-nav>li>a:hover {
-  border: 1px solid #23527c;
-}
-.article-nav-link-wrap .fa {
-  margin: 4px 0;
-}
-
-
-/*
- * Article media
- */
-.article-entry img,
-.article-entry video {
-  max-width: 100%;
-  height: auto;
-  display: block;
-  margin: auto;
-}
-.article-entry .caption {
-  color: #999;
-  display: block;
-  font-size: 0.9em;
-  margin-top: 0.5em;
-  position: relative;
-  text-align: center;
-}
-.article-entry .video-container {
-  position: relative;
-  padding-top: 56.25%;
-  height: 0;
-  overflow: hidden;
-}
-.article-entry .video-container iframe,
-.article-entry .video-container object,
-.article-entry .video-container embed {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  margin-top: 0;
-}
-
-.article-gallery {
-  padding-top: 15px;
-  border-top: 1px solid #eee;
-}
-
 /*
  * Archives
  */
@@ -374,23 +249,12 @@ code {
   margin-bottom: 30px;
 }
 
-.archive-year-wrap {
-  border-bottom: 1px solid #eee;
-  font-size: 2em;
-}
 .archive-year-wrap a,
 .archive-article .article-datetime a {
   color: #333;
   text-decoration: none;
 }
 
-.archive-article {
-  margin: 30px 0;
-}
-.archive-article h1 {
-  margin: 0;
-  font-size: 1.3em;
-}
 .archive-article .article-datetime a {
   color: #999;
   text-decoration: none;

--- a/source/css/hexo-base.css
+++ b/source/css/hexo-base.css
@@ -1,0 +1,172 @@
+/**
+ * Base Hexo and Theme styles
+ *
+ * This stylesheet is meant to give a baseline style
+ * for the built-in Hexo tags and theme markdown. They shouldn't need
+ * to change as often as the styles in `custom.css` (in theory).
+ */
+
+/* Globals */
+
+.left, .alignleft {
+  float: left;
+}
+.right, .alignright {
+  float: right;
+}
+
+/* Sidebar */
+
+.sidebar-module-list-count {
+  padding-left: 5px;
+}
+.sidebar-module-list-count:before { content: "("; }
+.sidebar-module-list-count:after { content: ")"; }
+
+/* Articles */
+
+.article-entry {
+  overflow: hidden; /* fixes problems on small width devices */
+}
+
+.article-meta {
+  margin-bottom: 20px;
+}
+.article-meta > * {
+  display: inline-block;
+  margin-right: 15px;
+}
+
+.article-date:before,
+.article-author:before,
+.article-category-link:before {
+  display: inline-block;
+  font-family: FontAwesome;
+  margin-right: 0.25em;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+}
+.article-date:before { content: "\f073"; }
+.article-author:before { content: "\f007"; }
+.article-category-link:before { content: "\f07b"; }
+
+/* blockquote */
+.article-entry blockquote footer cite {
+  display: inline-block;
+}
+.article-entry blockquote footer cite::before {
+  content: "~";
+  padding: 0px 0.5em;
+}
+
+.article-entry .pullquote.right {
+  margin-right: 0.5em;
+  margin-left: 1em;
+}
+.article-entry .pullquote {
+  text-align: left;
+  width: 45%;
+  margin: 0;
+}
+
+/* article tags */
+.article-tag-list {
+  margin: 0;
+  padding: 0;
+  list-style-type: none;
+}
+.article-tag-list-item {
+  display: inline-block;
+  margin-right: 15px;
+}
+.article-tag-list-link:before {
+  display: inline-block;
+  font-family: FontAwesome;
+  content: "\f02b";
+  margin-right: 0.25em;
+  text-rendering: auto;
+  -webkit-font-smoothing: antialiased;
+}
+
+.article-footer {
+  border-top: 1px solid #eee;
+  padding-top: 15px;
+}
+
+.article-comment-link { display: inline-block; }
+.article-share-link {
+  cursor: pointer;
+  float: right;
+  margin-left: 20px;
+}
+
+/* prev/next navigation between articles */
+#article-nav {
+  margin-top: 30px;
+}
+#article-nav>li {
+  padding: 2px;
+  font-size: 0.8em;
+}
+#article-nav>li>a {
+  border: 1px solid #337ab7;
+}
+#article-nav>li>a:hover {
+  border: 1px solid #23527c;
+}
+.article-nav-link-wrap .fa {
+  margin: 4px 0;
+}
+
+/* article media */
+
+.article-entry img,
+.article-entry video {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  margin: auto;
+}
+.article-entry .caption {
+  color: #999;
+  display: block;
+  font-size: 0.9em;
+  margin-top: 0.5em;
+  position: relative;
+  text-align: center;
+}
+.article-entry .video-container {
+  position: relative;
+  padding-top: 56.25%;
+  height: 0;
+  overflow: hidden;
+}
+.article-entry .video-container iframe,
+.article-entry .video-container object,
+.article-entry .video-container embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin-top: 0;
+}
+
+.article-gallery {
+  padding-top: 15px;
+  border-top: 1px solid #eee;
+}
+
+/* Archives */
+
+.archive-year-wrap {
+  border-bottom: 1px solid #eee;
+  font-size: 2em;
+}
+.archive-article {
+  margin: 30px 0;
+}
+.archive-article h1 {
+  margin: 0;
+  font-size: 1.3em;
+}

--- a/source/css/styles.styl
+++ b/source/css/styles.styl
@@ -1,5 +1,6 @@
 /* Concatenates the stylesheet files */
-@import "custom.css"
+@import "hexo-base.css"
 @import "callouts.css"
 @import "share-box.css"
 @import "highlight-js.css"
+@import "custom.css"


### PR DESCRIPTION
This change allows removing `custom.css` altogether, and the theme will still be visually functional. The critical styles have been moved out of `custom.css` into a `base-hexo.css`, giving designers an easier baseline to start from.
